### PR TITLE
Temporary horrible work around to allow certification into Splunk Cloud

### DIFF
--- a/README/inputs.conf.spec
+++ b/README/inputs.conf.spec
@@ -1,6 +1,9 @@
 [autofocus_export://<name>]
 label = 
-interval =
+#
+# Temporary horrible work around to allow certification into Cloud
+# https://github.com/PaloAltoNetworks/Splunk_TA_paloalto/issues/36
+#interval =
 
 [aperture://<name>]
 global_account =


### PR DESCRIPTION
Works around https://github.com/PaloAltoNetworks/Splunk_TA_paloalto/issues/36, certainly not ideal.. but alas I am not sure how to fix and we really need Splunk Cloud Ops to certify this.