### PR TITLE
Add host field extraction based on dvc_name

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -10,6 +10,12 @@ TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hip
 # Uncomment this if you need to index PAN-OS 6.1.0 threat logs
 # SEDCMD-6_1_0 = s/^((?:[^,]+,){3}THREAT,(?:[^,]*,){27}".*",[^,]*,)(\d+),((?:[^,]*,){3})(\d+,0x\d+,(?:[^,]*,){14})$/\1\3\4,\2/
 
+# Set the 'host' field based on dvc_name, if preferable.  Helpful
+# when Panorama or your syslog pathway masks the real host or IP.
+# Uncomment this if you would like to enable
+# TRANSFORMS-host = set_dvcname_as_host
+
+
 [pan:log]
 category = Network & Security
 description = Palo Alto Networks Next-generation Firewall and Traps Endpoint Protection
@@ -23,6 +29,12 @@ TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hip
 # the reportid field is at the end.
 # Uncomment this if you need to index PAN-OS 6.1.0 threat logs
 # SEDCMD-6_1_0 = s/^((?:[^,]+,){3}THREAT,(?:[^,]*,){27}".*",[^,]*,)(\d+),((?:[^,]*,){3})(\d+,0x\d+,(?:[^,]*,){14})$/\1\3\4,\2/
+
+# Set the 'host' field based on dvc_name, if preferable.  Helpful
+# when Panorama or your syslog pathway masks the real host or IP.
+# Uncomment this if you would like to enable
+# TRANSFORMS-host = set_dvcname_as_host
+
 
 [pan:firewall]
 category = Network & Security

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -197,6 +197,16 @@ REGEX = Client version: (?<agent_version>[^,]+)
 SOURCE_KEY =  description
 REGEX = Message: (?<agent_message>[^,]+)
 
+
+#### Set Syslog host (must enable in props.conf)
+
+[set_dvcname_as_host]
+# Note that CONFIG is in there twice, due to discrepancies between field extractions above and number of fields found in the wild.
+REGEX = ^((?:[^",\n]*+|"(?:[^"]*+|"")*"),){3}(?:THREAT,\g<1>{55}|TRAFFIC,\g<1>{48}|SYSTEM,\g<1>{18}|CONFIG,\g<1>{19}|CONFIG,\g<1>{17}|HIPMATCH,\g<1>{20}|CORRELATION,\g<1>{13}|USERID,\g<1>{20})([^,\r\n ]+)(?=,|$)
+FORMAT = host::$2
+DEST_KEY = MetaData:Host
+
+
 #### lookups
 
 [endpoint_actions_lookup]


### PR DESCRIPTION
- Added a new (off by default) transformer to extract the 'host' field based on
  the dvc_name field stored within the event.  This comes in handy when an
  incorrect host name is send in or somehow lost by some combination of
  syslog layers.  Users can choose to enable this for 'pan:log' or 'pan_log' if
  desirable.